### PR TITLE
Fix auth/failure route and controller

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -1,3 +1,5 @@
+#encoding: utf-8
+
 class AuthenticationsController < ApplicationController
   def index
     @authentications = current_member.authentications if current_member
@@ -48,6 +50,7 @@ class AuthenticationsController < ApplicationController
   end
   
    def failure
-    render :text => "Login Failure!"
+    flash[:notice] = "Falló la autenticacion"
+    redirect_to root_path
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Consonrisas::Application.routes.draw do
 
   match '/auth/facebook/logout' => 'application#facebook_logout', :as => :facebook_logout
   match '/auth/:provider/callback' => 'authentications#create'
-  match '/auth/failure' => 'users/authentications#failure'
+  match '/auth/failure' => 'authentications#failure'
   
   resources :authentications
 


### PR DESCRIPTION
Route auth/failure should point to 'authentications#failure'
Redirect to home in 'authentications#failure'

Me di cuenta de este problema trabajando en lo de FB. Es raro que FB no autentique pero por si acaso.
