### PR TITLE
Create facebook event

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'multi_json'
 
 gem 'twitter'
 
-gem 'fb_graph'
+gem 'fb_graph', '2.5.8'
 
 gem 'iron_worker'
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,7 @@ class Event < ActiveRecord::Base
   #validate :at_least_one_fundation  
   #validates :fundations, :uniqueness => {:scope => :event_id}
   
-  after_create :generate_alerts
+  after_create :generate_alerts, :create_fb_event
       
   def ask_admin member_id
     EventAdmin.create(:member_id =>member_id, :event_id => self.id, :active=>false)
@@ -89,5 +89,15 @@ class Event < ActiveRecord::Base
   def generate_alerts
     GlobalAlert.create(:news=>"Se creó el evento: ", :model=>"Event", :model_id=>id, :name_link=>name)
   end
+
+  def create_fb_event
+    begin
+      page = FbGraph::Page.new(Consonrisas::Application.config.fb.page_id)
+      event = page.event!(:access_token => Consonrisas::Application.config.fb.auth_token, :name => self.name, :start_time => self.date, :location => self.city + " - " + self.place)
+    rescue => e
+      puts "Error posting event to facebook: #{e.inspect}"
+    end
+  end
+  handle_asynchronously :create_fb_event
   
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,7 +49,7 @@ ActionMailer::Base.smtp_settings = {
   config.autoload_paths += %W( #{::Rails.root.to_s}/app/workers )
 
   config.fb.page_id = ENV['FB_PAGE_ID'] || '530935246927411'
-  config.fb.auth_token = ENV['FB_AUTH_TOKEN'] || 'AAACS5JoBfWYBAFOXRqCMQEJ5bpYwHwZBZCrlfLopffZCtgAuYJANI1vJyHkmum0jNmlZCZC2TsZCRrC2nLL4ZAWZAPpMQeYZCkx4p42jiRfpFdu0XwC25ZBURo'
+  config.fb.auth_token = ENV['FB_AUTH_TOKEN'] || 'AAACS5JoBfWYBAPHHTdmpfwq4ztThec4HghiI01cLrHwNpxxsz6VagRwx4dCfEILuMaJyxCyOheKSRryO1hcZBVeHn2ZCJ6QmwXZBMJH55p5v45jK6vZB'
 
   config.twitter.consumer_key = ENV['TWITTER_CONSUMER_KEY'] || 'bO99GGfXFk2El5vBijNDQ'
   config.twitter.consumer_secret = ENV['TWITTER_CONSUMER_SECRET'] || 'JjWmNG4UvoyA1ahNyuTXiuNWzCGmdHvdPM5SCfuiWI'


### PR DESCRIPTION
Add an after_create method to the event.rb file.
Change the access_token in the development.rb file.
Set the version of the fb_graph to 2.5.8.

Esto es apenas lo que llevo :S. Y todavía tengo un problema: si creo un evento a las 7pm en Facebook me sale a las 2pm. No sé si este problema también pase en Heroku. Al parecer no está cogiendo bien mi timezone o algo.

Quedaría pendiente editar y eliminar el evento. Para esto necesitaríamos crear otro campo en la base de datos donde guardemos el id del evento.

Fíjese en la versión de fb_graph. Me tocó quemarla ahí en el Gemfile.

Me cuenta cómo lo ve.
